### PR TITLE
Add keywords counter into log parsing

### DIFF
--- a/jobs/HighlightedErrors.json
+++ b/jobs/HighlightedErrors.json
@@ -1,0 +1,3 @@
+{
+    "keywords": ["error", "warning", "keyword3"]
+}


### PR DESCRIPTION
Each test case will include keywords counter in 'test case status' column:
Found 'error' in logs: 5
Found 'warning' in logs: 7

https://luxproject.luxoft.com/jira/browse/STVCIS-3152